### PR TITLE
[snowflake] implement a basic snowflake executor using typescript sdk

### DIFF
--- a/packages/malloy-db-snowflake/package.json
+++ b/packages/malloy-db-snowflake/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@datairis/db-snowflake",
+  "version": "0.0.1",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/datairisplatform/malloy"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "lint": "eslint '**/*.ts{,x}'",
+    "lint-fix": "eslint '**/*.ts{,x}' --fix",
+    "test": "jest --config=../../jest.config.js",
+    "build": "tsc --build",
+    "clean": "tsc --build --clean",
+    "malloyc": "ts-node ../../scripts/malloy-to-json",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@malloydata/malloy": "^0.0.100",
+    "@types/snowflake-sdk": "^1.6.16",
+    "fs": "^0.0.1-security",
+    "generic-pool": "^3.9.0",
+    "path": "^0.12.7",
+    "snowflake-sdk": "^1.9.0",
+    "toml": "^3.0.0"
+  }
+}

--- a/packages/malloy-db-snowflake/src/index.ts
+++ b/packages/malloy-db-snowflake/src/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+export {SnowflakeExecutor} from './snowflake_executor';

--- a/packages/malloy-db-snowflake/src/snowflake_executor.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {SnowflakeExecutor, SnowflakeQueryOptions} from './snowflake_executor';
+import {QueryData} from '@malloydata/malloy';
+
+class SnowflakeExecutorTestSetup {
+  private executor_: SnowflakeExecutor;
+  constructor(private executor?: SnowflakeExecutor) {
+    if (executor === undefined) {
+      executor = new SnowflakeExecutor();
+    }
+    this.executor_ = executor;
+  }
+
+  async runBatch(sqlText: string): Promise<QueryData> {
+    let ret: QueryData = [];
+    await (async () => {
+      const rows = await this.executor_.batch(sqlText);
+      return rows;
+    })().then((rows: QueryData) => {
+      ret = rows;
+    });
+    return ret;
+  }
+
+  async runStreaming(sqlText: string, queryOptions?: SnowflakeQueryOptions) {
+    const rows: QueryData = [];
+    await (async () => {
+      for await (const row of await this.executor_.stream(
+        sqlText,
+        queryOptions
+      )) {
+        rows.push(row);
+      }
+    })();
+    return rows;
+  }
+
+  async done() {
+    await this.executor_.done();
+  }
+}
+
+describe('db:SnowflakeExecutor', () => {
+  let db: SnowflakeExecutorTestSetup;
+  let query: string;
+
+  beforeAll(() => {
+    db = new SnowflakeExecutorTestSetup();
+    query = `
+    select
+    *
+  from
+    (
+      values
+        (1, 'one'),
+        (2, 'two'),
+        (3, 'three'),
+        (4, 'four'),
+        (5, 'five')
+    );
+    `;
+  });
+
+  afterAll(async () => {
+    await db.done();
+  });
+
+  it('verifies batch execute', async () => {
+    const rows = await db.runBatch(query);
+    expect(rows.length).toBe(5);
+  });
+
+  it('verifies stream iterable', async () => {
+    const rows = await db.runStreaming(query, {rowLimit: 2});
+    expect(rows.length).toBe(2);
+  });
+});

--- a/packages/malloy-db-snowflake/src/snowflake_executor.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import snowflake, {
+  SnowflakeError,
+  Statement,
+  Connection,
+  ConnectionOptions,
+} from 'snowflake-sdk';
+import {Pool, Options as PoolOptions} from 'generic-pool';
+import * as toml from 'toml';
+import * as fs from 'fs';
+import * as path from 'path';
+import {Readable} from 'stream';
+import {toAsyncGenerator, QueryData, QueryDataRow} from '@malloydata/malloy';
+
+export interface SnowflakeQueryOptions {
+  rowLimit: number;
+}
+
+interface ConnectionConfigFile {
+  // if not supplied "default" connection is used
+  connection_name?: string;
+  connection_file_path: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isConnectionConfig(obj: any): obj is ConnectionOptions {
+  return obj && obj.account && obj.user;
+}
+
+export class SnowflakeExecutor {
+  private pool_: Pool<Connection>;
+  private defaultPoolOptions_: PoolOptions = {
+    min: 0,
+    max: 1,
+    evictionRunIntervalMillis: 60000, // default = 0, off
+    idleTimeoutMillis: 60000, // default = 30000
+  };
+
+  constructor(
+    connOptions?: ConnectionOptions | ConnectionConfigFile,
+    poolOptions?: PoolOptions
+  ) {
+    this.pool_ = snowflake.createPool(this.getConnectionOptions(connOptions), {
+      ...this.defaultPoolOptions_,
+      ...(poolOptions ?? {}),
+    });
+  }
+
+  private getConnectionOptions(
+    options?: ConnectionOptions | ConnectionConfigFile
+  ): ConnectionOptions {
+    const defaultOptions = {
+      clientSessionKeepAlive: true, // default = false
+      clientSessionKeepAliveHeartbeatFrequency: 900, // default = 3600
+    };
+
+    if (isConnectionConfig(options)) {
+      return {...defaultOptions, ...options};
+    }
+
+    let location: string | undefined = options?.connection_file_path;
+    if (location === undefined) {
+      const homeDir = process.env['HOME'] || process.env['USERPROFILE'];
+      if (homeDir === undefined) {
+        throw new Error(
+          'must provide either snowflake ConnectionOptions via constructor or path to a connections.toml'
+        );
+      }
+      location = path.join(homeDir, '.snowflake', 'connections.toml');
+    }
+
+    if (!fs.existsSync(location)) {
+      throw new Error(
+        `provided snowflake connection config file: ${options} does not exist`
+      );
+    }
+
+    const tomlData = fs.readFileSync(location, 'utf-8');
+    const connections = toml.parse(tomlData);
+
+    const connection = connections[options?.connection_name ?? 'default'];
+    if (!connection || !connection.account || !connection.user) {
+      throw new Error(
+        `provided snowflake connection config file: ${options} is not valid`
+      );
+    }
+
+    return {
+      // some basic options we configure by default but can be overriden
+      ...defaultOptions,
+      account: connection.account,
+      username: connection.user,
+      password: connection.password,
+      warehouse: connection.warehouse,
+      database: connection.database,
+      schema: connection.schema,
+      ...connection,
+    };
+  }
+
+  public async done() {
+    await this.pool_.drain().then(() => {
+      this.pool_.clear();
+    });
+  }
+
+  public async batch(sqlText: string): Promise<QueryData> {
+    return await this.pool_.use(async (conn: Connection) => {
+      return new Promise((resolve, reject) => {
+        const _statment = conn.execute({
+          sqlText,
+          complete: (
+            err: SnowflakeError | undefined,
+            _stmt: Statement,
+            rows?: QueryData
+          ) => {
+            if (err) {
+              reject(err);
+            } else if (rows) {
+              resolve(rows);
+            }
+          },
+        });
+      });
+    });
+  }
+
+  public async stream(
+    sqlText: string,
+    options?: SnowflakeQueryOptions
+  ): Promise<AsyncIterableIterator<QueryDataRow>> {
+    const pool: Pool<Connection> = this.pool_;
+    return await pool.acquire().then(async (conn: Connection) => {
+      const stmt: Statement = conn.execute({
+        sqlText,
+        streamResult: true,
+      });
+      const stream: Readable = stmt.streamRows();
+      function streamSnowflake(
+        onError: (error: Error) => void,
+        onData: (data: QueryDataRow) => void,
+        onEnd: () => void
+      ) {
+        function handleEnd() {
+          onEnd();
+          pool.release(conn);
+        }
+
+        let index = 0;
+        function handleData(this: Readable, row: QueryDataRow) {
+          onData(row);
+          index += 1;
+          if (options?.rowLimit !== undefined && index >= options.rowLimit) {
+            onEnd();
+          }
+        }
+        stream.on('error', onError);
+        stream.on('data', handleData);
+        stream.on('end', handleEnd);
+      }
+      return Promise.resolve(toAsyncGenerator<QueryDataRow>(streamSnowflake));
+    });
+  }
+}

--- a/packages/malloy-db-snowflake/tsconfig.json
+++ b/packages/malloy-db-snowflake/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../malloy"
+    }
+  ]
+}


### PR DESCRIPTION
- Implement a connection pool
- Implement streaming
- Implement basic reading of connection options from .snowflake for testing
- Run basic test for streaming and batch options

TODO (much later):
- add resumability for a given request
- add support for multiple statements

```
[nix-shell:~/code/malloy2]$ npx jest --runInBand packages/malloy-db-snowflake/src/snowflake_executor.spec.ts
 PASS  packages/malloy-db-snowflake/src/snowflake_executor.spec.ts
  db:SnowflakeExecutor
    ✓ verifies batch execute (932 ms)
    ✓ verifies stream iterable (291 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        2.246 s
Ran all test suites matching /packages\/malloy-db-snowflake\/src\/snowflake_executor.spec.ts/i.
```