### PR TITLE
convert databricks DECIMAL type to float

### DIFF
--- a/packages/malloy/src/dialect/databricks/databricks.ts
+++ b/packages/malloy/src/dialect/databricks/databricks.ts
@@ -53,6 +53,7 @@ const databricksToMalloyTypes: {[key: string]: LeafAtomicTypeDef} = {
   'int': {type: 'number', numberType: 'integer'},
   'bigint': {type: 'number', numberType: 'integer'},
   'double': {type: 'number', numberType: 'float'},
+  'decimal': {type: 'number', numberType: 'float'},
   'timestamp_ntz': {type: 'timestamp'}, // maybe not
   'boolean': {type: 'boolean'},
   'timestamp': {type: 'timestamp'},


### PR DESCRIPTION
Quick fix to support DECIMAL type in databricks. Right now the malloy package converts decimal to "sql native"