### PR TITLE
[malloy core] Fix Broken Table Schema Query

### DIFF
--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -343,23 +343,51 @@ export class SnowflakeConnection
       // * remove fields for which we have multiple types
       //   ( requires folding decimal to integer )
       const sampleQuery = `
-        select path, min(type) as type
-        from (
-          select
-            regexp_replace(path, '\\\\[[0-9]+\\\\]', '[*]') as path,
-            case
-              when typeof(value) = 'INTEGER' then 'decimal'
-              when typeof(value) = 'DOUBLE' then 'decimal'
-            else lower(typeof(value)) end as type
-          from
-            (select object_construct(*) o from ${tablePath} limit 100)
-              ,table(flatten(input => o, recursive => true)) as meta
-          group by 1,2
-        )
-        where type != 'null_value'
-        group BY 1
-        having count(*) <=1
-        order by path;
+WITH base AS (
+  SELECT
+    regexp_replace(path, '\\\\[[0-9]+\\\\]', '[*]') AS norm_path,
+    CASE
+      WHEN typeof(value) = 'INTEGER' THEN 'decimal'
+      WHEN typeof(value) = 'DOUBLE'   THEN 'decimal'
+      ELSE lower(typeof(value))
+    END AS type
+  FROM (
+         SELECT object_construct(*) o
+         FROM ${tablePath}
+         LIMIT 100
+       )
+       , table(flatten(input => o, recursive => true)) AS meta
+  WHERE lower(typeof(value)) != 'null_value'
+),
+agg AS (
+  SELECT
+    norm_path,
+    min(type) AS type,
+    count(distinct type) AS type_count
+  FROM base
+  GROUP BY norm_path
+),
+ambiguous AS (
+  SELECT
+    norm_path,
+    replace(replace(norm_path, '[', '\\['), ']', '\\]') AS esc_norm_path
+  FROM agg
+  WHERE type_count > 1
+)
+SELECT a.norm_path AS path, a.type
+FROM agg a
+WHERE a.type_count = 1
+  -- now only include nodes that are a descendant of an ambiguous node
+  AND NOT EXISTS (
+    SELECT 1
+    FROM ambiguous b
+    WHERE a.norm_path <> b.norm_path
+      AND (
+           a.norm_path LIKE b.esc_norm_path || '.%' ESCAPE '\\\\'
+        OR a.norm_path LIKE b.esc_norm_path || '[%' ESCAPE '\\\\'
+      )
+  )
+ORDER BY a.norm_path;
       `;
       const fieldPathRows = await this.executor.batch(sampleQuery);
 


### PR DESCRIPTION
TLDR: SQL query for table schema had a small but deadly error resulting in a crash.

Today, Malloy does not support any variant types. This means that arbitrary json objects need to have a fixed schema. The code as it was written ignores situations where an object might have an int or a string type. HOWEVER, one important thing the current code does not account for is having multiple collection types potentially. 

Lets take an example:
if "abc" is a json object that contains the keys "name" and "value" and "value" can sometimes be string and sometimes int, malloy for snowflake will just ignore the untypable field (I think, but based on comments in the code this is true).

BUT if "abc" has a key "stuff" which can be EITHER a json or an array object, snowflake will skip processing this field but might still try to process "stuff".value or "stuff"[0]. 

This results in a crash.

The fix in this PR is to ensure that when we are querying for the table schema, we drop all descendants of ambiguous columns along with that column. This will ensure the rest of the code does not crash and that we can actively read information from such fully variant things.